### PR TITLE
Fix on remove player

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -156,6 +156,7 @@
   }
 
   function onRemovePlayer(data) {
+    console.log('onRemovePlayer invoked');
     var newRemotePlayers = {};
     for (var id in remotePlayers) {
       if (id !== data.id) {
@@ -163,6 +164,7 @@
       }
     }
     remotePlayers = newRemotePlayers;
+    console.log('remotePlayers: ' + JSON.stringify(remotePlayers));
   }
 
   function onInitialBricks(data) {


### PR DESCRIPTION
This fixes the bug that causes a client to disconnect because of an error thrown by Phaser when using `delete` in the client.
