### PR TITLE
Fix frozen remote gameOver ball

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -185,6 +185,13 @@
   }
 
   function createRemoteBall(data) {
+    console.log('createRemoteBall invoked');
+
+    if (remotePlayers[data.remotePlayerID].gameOver === true) {
+      console.log("createRemoteBall exiting early because remote player's game is over");
+      return;
+    }
+
     var remoteBall = game.add.sprite(data.posX, data.posY, 'breakout', 'ball_1.png');
     remoteBall.anchor.set(0.5);
     remoteBall.checkWorldBounds = true;
@@ -243,6 +250,7 @@
     socket.on('update ball', onUpdateRemoteBall);
     socket.on('update local score', onUpdateLocalScore);
     socket.on('update remote score', onUpdateRemoteScore);
+    socket.on('remote player game over', onRemotePlayerGameOver);
   }
 
   function onKillRemoteBall(data) {
@@ -299,6 +307,7 @@
       name: data.name,
       score: data.score,
       color: data.color,
+      gameOver: data.gameOver,
       paddleX: game.world.centerX
     };
     addPlayerToLeaderboard(data);
@@ -512,6 +521,8 @@
 
     infoText.text = 'Game Over!';
     infoText.visible = true;
+
+    socket.emit('player game over');
   }
 
   function ballHitBrick(_ball, _brick) {
@@ -577,6 +588,12 @@
       }
     });
   };
+
+  function onRemotePlayerGameOver(data) {
+    if (typeof remotePlayers[data.id] !== 'undefined') {
+      remotePlayers[data.id].gameOver = true;
+    }
+  }
 
   function padHex(n, width) {
     n = n + '';

--- a/server.js
+++ b/server.js
@@ -34,6 +34,7 @@ function onSocketConnection(client) {
   client.on('existing ball', onExistingBall);
   client.on('kill remote ball', onKillRemoteBall);
   client.on('update ball', onUpdateBall);
+  client.on('player game over', onPlayerGameOver);
 }
 
 function onUpdateBall(data) {
@@ -101,7 +102,8 @@ function onNewPlayer(data) {
         id: playerID,
         name: players[playerID].name,
         score: players[playerID].score,
-        color: players[playerID].color
+        color: players[playerID].color,
+        gameOver: players[playerID].gameOver
       });
     }
   }
@@ -115,14 +117,16 @@ function onNewPlayer(data) {
   this.emit('local player', {
     id: this.id,
     name: funnyName,
-    color: color
+    color: color,
+    gameOver: false
   });
 
   // Add new player to players array
   players[this.id] = {
     color: color,
     name: funnyName,
-    score: 0
+    score: 0,
+    gameOver: false
   };
   util.log(this.id + ' added to players');
   util.log('players = ' + util.inspect(players, utilInspectOpts));
@@ -132,7 +136,8 @@ function onNewPlayer(data) {
     id: this.id,
     name: funnyName,
     color: color,
-    score: 0
+    score: 0,
+    gameOver: false
   });
   util.log(this.id + ' broadcast to all existing players');
 }
@@ -207,6 +212,13 @@ function onUpdatePaddlePosition(data) {
   this.broadcast.emit('update paddle position', {
     id: this.id,
     x: data.x
+  });
+}
+
+function onPlayerGameOver() {
+  players[this.id].gameOver = true;
+  this.broadcast.emit('remote player game over', {
+    id: this.id,
   });
 }
 


### PR DESCRIPTION
This adds a `gameOver` property to each `player` object on both the client and server. The remote player's ball is not rendered if that remote player has their `gameOver` property set to `true`. This prevents a frozen ball from being rendered at the bottom of the world bounds when a new player joins a game that has an existing player in the game over state.

This addresses Issue https://github.com/nsue/multiplayer-breakout/issues/18
